### PR TITLE
Disallow newlines after dots in member expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ module.exports = {
     "dot-notation": 2,
 
     // enforces consistent newlines before or after dots (off by default)
-    "dot-location": [2, "object"],
+    "dot-location": [2, "property"],
 
     // require the use of === and !==
     "eqeqeq": 2,


### PR DESCRIPTION
Change configuration of the [dot-location](http://eslint.org/docs/rules/dot-location) rule.

With this rule change the following will be disallowed:

```js
things.
    filter(fn).
    sort();
```

and this will be allowed:

```js
things
    .filter(fn)
    .sort();

things.filter(fn).sort();
```
