### PR TITLE
Warn if comments are not preceded by an empty line

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,7 +383,9 @@ module.exports = {
       1,
       {
         "beforeBlockComment": true,
-        "beforeLineComment": true
+        "afterBlockComment": false,
+        "beforeLineComment": true,
+        "afterLineComment": false
       }
     ],
 


### PR DESCRIPTION
The [lines-around-comment](http://eslint.org/docs/rules/lines-around-comment) rule will warn if a comment is not preceded by an empty line.

The reason for this commit is to not require an empty line after comment.

This might be pushing it a bit too far :) We can disable this rule if it is too obnoxious...
