### PR TITLE
Warn when chai, should or sinon are required

### DIFF
--- a/index.js
+++ b/index.js
@@ -328,6 +328,9 @@ module.exports = {
     // disallow process.exit() (on by default in the node environment)
     "no-process-exit": 2,
 
+    // restrict usage of specified node modules (off by default)
+    "no-restricted-modules": [1, "chai", "should", "should-http", "should-promised", "should-sinon", "sinon", "sinon-chai"],
+
     // disallow use of synchronous methods (off by default)
     "no-sync": 1,
 


### PR DESCRIPTION
This rule will warn if any of the modules are `require`d.

The point of using this rule is to help migrate from `chai` and `should` to `springworks/test-harness`.

The restricted modules are: `chai`, `should`, `should-http`, `should-promised`, `should-sinon`, `sinon` and `sinon-chai`.