### PR TITLE
Enforce return after calling resolve or reject

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,7 +329,7 @@ module.exports = {
      */
 
     // enforce return after a callback
-    "callback-return": [1, ["callback", "cb", "next", "done"]],
+    "callback-return": [1, ["callback", "cb", "next", "done", "resolve", "reject"]],
 
     // enforces error handling in callbacks (on by default in the node environment)
     "handle-callback-err": [2, "^(.+_)?err(or)?$"],


### PR DESCRIPTION
When using `new Promise(function(resolve, reject) { ... });` the `resolve` and `reject` arguments should be treated as callbacks.