### PR TITLE
Enforce one variable declaration for each variable

### DIFF
--- a/index-config.json
+++ b/index-config.json
@@ -129,7 +129,7 @@
     "no-warning-comments": 1,
     "no-with": 2,
     "object-curly-spacing": [2, "always"],
-    "one-var": 0,
+    "one-var": [1, "never"],
     "operator-assignment": 0,
     "operator-linebreak": [2, "after"],
     "padded-blocks": [2, "never"],


### PR DESCRIPTION
The example code already reflect this principle but the change means that we get a warning if multiple variables are defined with a single declaration: `var a, b;`.