### PR TITLE
Use the springworks plugin in our shared config

### DIFF
--- a/index-config.json
+++ b/index-config.json
@@ -2,7 +2,12 @@
   "env": {
     "node": true
   },
+  "plugins": [
+    "springworks"
+  ],
   "rules": {
+    "springworks/no-require-file-extension": 1,
+
     "accessor-pairs": 0,
     "array-bracket-spacing": [2, "never"],
     "block-scoped-var": 2,

--- a/mocha-config.json
+++ b/mocha-config.json
@@ -3,12 +3,16 @@
     "mocha": true
   },
   "plugins": [
+    "springworks",
     "mocha"
   ],
   "rules": {
-    "max-nested-callbacks": 0,
+    "springworks/top-describe-path": 1,
+
     "mocha/handle-done-callback": 2,
     "mocha/no-exclusive-tests": 2,
+
+    "max-nested-callbacks": 0,
     "no-extra-parens": 0,
     "no-sync": 0,
     "no-wrap-func": 0,

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   "peerDependencies": {
     "eslint": "^1.8.0",
     "eslint-plugin-import": ">=0.8.1 <1.0.0",
-    "eslint-plugin-mocha": "^1.0.0"
+    "eslint-plugin-mocha": "^1.0.0",
+    "eslint-plugin-springworks": "^1.1.1"
   },
   "devDependencies": {
     "babel-eslint": "4.1.6",
     "eslint": "1.10.2",
     "eslint-plugin-import": "0.11.0",
-    "eslint-plugin-mocha": "1.1.0"
+    "eslint-plugin-mocha": "1.1.0",
+    "eslint-plugin-springworks": "1.1.1"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
- The `no-require-file-extension` rule is set to _warn_ in the default and babel configs
- The `top-describe-path` rule is set to _warn_ in the mocha config