### PR TITLE
Enforce require() on the top-level module scope

### DIFF
--- a/index-config.json
+++ b/index-config.json
@@ -29,7 +29,7 @@
     "eqeqeq": 2,
     "func-names": 0,
     "func-style": [2, "declaration"],
-    "global-require": 1,
+    "global-require": 2,
     "guard-for-in": 2,
     "handle-callback-err": [2, "^(.+_)?err(or)?$"],
     "indent": 0,


### PR DESCRIPTION
Change the [global-require](http://eslint.org/docs/rules/global-require) to error level.

Use of `require` anywhere but the top of the file should be avoided.