### PR TITLE
Add allowArrowFunctions option to func-style

### DIFF
--- a/index-config.json
+++ b/index-config.json
@@ -30,7 +30,7 @@
     "eol-last": 2,
     "eqeqeq": 2,
     "func-names": 0,
-    "func-style": [2, "declaration"],
+    "func-style": [2, "declaration", { "allowArrowFunctions": true }],
     "generator-star-spacing": [2, { "before": true, "after": false }],
     "global-require": 2,
     "guard-for-in": 2,


### PR DESCRIPTION
This will make the linter allow

```js
const fn = () => {};
obj.fn = () => {};
```

http://eslint.org/docs/rules/func-style