### PR TITLE
Remove radix linting rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,6 @@ module.exports = {
     "prefer-template": 1,
     "quote-props": [2, "as-needed"],
     "quotes": [2, "single", "avoid-escape"],
-    "radix": 2,
     "require-yield": 2,
     "semi": [2, "always"],
     "semi-spacing": [2, { "before": false, "after": true }],


### PR DESCRIPTION
I suggest we remove the radix linting rule (or perhaps switch to warn) since the octal parsing issue no longer affects node.js.

I believe this rule stems from the fact that `parseInt('010')` would return 8 previously, since radix 8 was inferred from the preceding `0`. Nowadays only hexadeximal radix is inferred from the `0x` prefix, which IMO makes this linting rule redundant (but not for browsers though), since we only target Node.js with this?