### PR TITLE
fix(space-before-function-paren): require space for `async`

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ module.exports = {
     "semi": [2, "always"],
     "semi-spacing": [2, { "before": false, "after": true }],
     "space-before-blocks": [2, "always"],
-    "space-before-function-paren": [2, "never"],
+    "space-before-function-paren": [2, { "anonymous": "never", "named": "never", "asyncArrow": "always" }],
     "space-in-parens": [2, "never"],
     "space-infix-ops": 2,
     "space-unary-ops": 2,


### PR DESCRIPTION
See http://eslint.org/docs/rules/space-before-function-paren